### PR TITLE
fix: inherit cost basis from pre-split shares in Section 104 pool

### DIFF
--- a/src/capital-gains/section104.ts
+++ b/src/capital-gains/section104.ts
@@ -6,19 +6,61 @@ export class Section104 {
     private _allocatedTrades: AllocatedStockTrade[]
     private _qty: number
     private _totalCostInBase: number
+    private _consumedByReorg: Set<AllocatedStockTrade>
 
     constructor(symbol: string, trades: AllocatedStockTrade[]) {
         this._symbol = symbol
         this._qty = 0
         this._totalCostInBase = 0
+        this._consumedByReorg = new Set()
         // Don't filter by symbol - the caller (StockHolding) already filters by canonical symbol,
         // and trades may have different symbols due to ticker renames (IC, RS, FS corporate actions)
         this._allocatedTrades = trades.filter(t => t.trade.buyOrSell === 'BUY')
 
+        // Sort by date for chronological processing
+        const sortedTrades = [...this._allocatedTrades].sort(
+            (a, b) => a.trade.dateTime.getTime() - b.trade.dateTime.getTime()
+        )
+
+        // Find all reorganization buys (from RS/FS corporate actions)
+        // These represent shares after a stock split and should inherit cost basis
+        // from all shares that existed before the reorganization
+        const reorgBuys = sortedTrades.filter(t => t.trade.isReorganizationBuy)
+
+        for (const reorgBuy of reorgBuys) {
+            const reorgDate = reorgBuy.trade.dateTime
+
+            // Calculate the cost basis of all unconsumed shares bought before this reorganization
+            let priorCost = 0
+            for (const trade of sortedTrades) {
+                if (trade.trade.dateTime >= reorgDate) continue
+                if (this._consumedByReorg.has(trade)) continue
+                if (trade.trade.isReorganizationBuy) continue // Don't double-count prior reorg buys
+                if (trade.qtyLeft === 0) continue
+
+                priorCost += trade.netPriceInBase(trade.qtyLeft)
+                this._consumedByReorg.add(trade)
+            }
+
+            // The reorganization buy inherits the entire prior cost basis
+            // Store this for later use when calculating the pool
+            ;(reorgBuy as any)._inheritedCostInBase = priorCost
+        }
+
+        // Now calculate the pool totals
         for (const allocatedTrade of this._allocatedTrades) {
             if (allocatedTrade.qtyLeft === 0) continue
 
-            this._totalCostInBase += allocatedTrade.netPriceInBase(allocatedTrade.qtyLeft)
+            // Skip trades that were consumed by a reorganization
+            if (this._consumedByReorg.has(allocatedTrade)) continue
+
+            if (allocatedTrade.trade.isReorganizationBuy) {
+                // Use the inherited cost basis instead of the trade's zero cost
+                const inheritedCost = (allocatedTrade as any)._inheritedCostInBase || 0
+                this._totalCostInBase += inheritedCost
+            } else {
+                this._totalCostInBase += allocatedTrade.netPriceInBase(allocatedTrade.qtyLeft)
+            }
             this._qty += allocatedTrade.qtyLeft
         }
     }
@@ -34,6 +76,9 @@ export class Section104 {
     private allocateStockTrades(qty: number) {
         let qtyLeft = qty
         for (const t of this._allocatedTrades) {
+            // Skip trades that were consumed by a reorganization
+            if (this._consumedByReorg.has(t)) continue
+
             const qtyToAllocate = Math.min(t.qtyLeft, qtyLeft)
             t.allocate(qtyToAllocate)
             qtyLeft -= qtyToAllocate


### PR DESCRIPTION
## Summary
- Fixes incorrect cost basis calculation for stocks that underwent reverse/forward splits (RS/FS)
- When a split occurs, the new shares now correctly inherit the cost basis from the original pre-split shares
- Previously, reorganization buy trades were added to the Section 104 pool with zero cost, resulting in incorrect (near-zero) cost basis calculations

## Example
AONE (400 shares @ ~$12.50, cost basis ~$5000) → MKFG (40 shares via 1:10 reverse split)
- **Before**: Cost basis shown as £327 (incorrect - used zero-cost reorganization buy)
- **After**: Cost basis shown as £3600 (correct - inherited from original AONE purchase)

## Test plan
- [x] Verified MKFG cost basis matches original AONE purchase cost
- [x] Verified proceeds calculation is correct
- [x] Verified gain/loss calculation is correct
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)